### PR TITLE
hasura-cli@v2.x.y docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /hasuracli
 USER hasuracli
 
 # Install HasuraCLI
-RUN curl -L https://github.com/hasura/graphql-engine/raw/master/cli/get.sh | INSTALL_PATH=/hasuracli bash
+RUN curl -L https://github.com/hasura/graphql-engine/raw/stable/cli/get.sh | INSTALL_PATH=/hasuracli bash
 
 # Run Hasura on start
 ENTRYPOINT ["/hasuracli/hasura"]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,21 @@ Your migrations folder should resemble the below:
 ```
 .
 ├── config.yaml
+└── metadata
 └── migrations
-    └── metadata.json
+   └── metadata.json
+└── seeds
 ```
 
 Usage:
 
-`docker run --restart on-failure --rm --volume /path/to/your/migrations/folder:/hasuracli/migrations docker.io/dvasdekis/hasura-cli-docker:latest metadata apply --endpoint "http://your_hasura_address:80" --admin-secret "your_hasura_admin_secret" --project migrations`
+[Optional] Init project - migrations:\
+`docker run --rm --mount type=bind,source="/path/to/your/migrations_home",target=/hasuracli:rw docker.io/dvasdekis/hasura-cli-docker:latest init migrations --endpoint "http://your_hasura_address:80" --admin-secret "your_hasura_admin_secret"`
 
-[Docker Hub link](https://hub.docker.com/repository/docker/dvasdekis/hasura-cli-docker)
+Run/Apply migrations:\
+`docker run --restart on-failure --rm --volume /path/to/your/migrations/folder:/hasuracli/migrations docker.io/dvasdekis/hasura-cli-docker:latest metadata apply --endpoint "http://your_hasura_address:80" --admin-secret "your_hasura_admin_secret" --project migrations`  
+\
+[Docker Hub link](https://hub.docker.com/repository/docker/dvasdekis/hasura-cli-docker) \
+[Cli Docs](https://hasura.io/docs/latest/graphql/core/hasura-cli/index/)
 
-Hasura CLI version: v1.3.3
+Hasura CLI version: v2.4.0


### PR DESCRIPTION
@dvasdekis 
Please publish Docker image v2.4.0 to dockerhub with this changes

Changes:
 - Use stable branch for cli@2.X.X installation in order to use recent/latest cli version in image. See [README.md](https://github.com/hasura/graphql-engine/tree/master/cli#download-graphql-engine-cli-bundled-with-hasura-cli)/[Docs](https://hasura.io/docs/latest/graphql/core/hasura-cli/install-hasura-cli/#install-a-binary-globally) for reference.
 - update README.md: update versions/links+provide init example.
